### PR TITLE
Resolved an issue where some registrar whois server results contained a

### DIFF
--- a/lib/whois.ex
+++ b/lib/whois.ex
@@ -66,8 +66,8 @@ defmodule Whois do
       |> String.trim()
       |> String.downcase()
       |> case do
-        "whois server:" <> host -> String.trim(host)
-        "registrar whois server:" <> host -> String.trim(host)
+        "whois server:" <> host -> host |> String.trim |> String.trim("/")
+        "registrar whois server:" <> host -> host |> String.trim |> String.trim("/")
         _ -> nil
       end
     end)

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,4 @@
-%{"earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"}}
+%{
+  "earmark": {:hex, :earmark, "1.4.4", "4821b8d05cda507189d51f2caeef370cf1e18ca5d7dfb7d31e9cafe6688106a4", [:mix], [], "hexpm", "1f93aba7340574847c0f609da787f0d79efcab51b044bb6e242cae5aca9d264d"},
+  "ex_doc": {:hex, :ex_doc, "0.18.4", "4406b8891cecf1352f49975c6d554e62e4341ceb41b9338949077b0d4a97b949", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm", "9dbe1ce1d711dc5362e3b3280e92989ad61413ce423bc4e9f76d5fcc51ab8d6b"},
+}


### PR DESCRIPTION
trailing slash, which was causing the entire lookup to return an
{:error, :nxdomain} despite an otherwise successful result