### PR TITLE
Add DNSSEC parsing with handling of unsynced values. See cloudflare.com

### DIFF
--- a/lib/whois/record.ex
+++ b/lib/whois/record.ex
@@ -5,6 +5,7 @@ defmodule Whois.Record do
     :domain,
     :raw,
     :nameservers,
+    :dnssec,
     :registrar,
     :created_at,
     :updated_at,
@@ -16,6 +17,7 @@ defmodule Whois.Record do
           domain: String.t(),
           raw: String.t(),
           nameservers: [String.t()],
+          dnssec: String.t(),
           registrar: String.t(),
           created_at: NaiveDateTime.t(),
           updated_at: NaiveDateTime.t(),
@@ -61,7 +63,10 @@ defmodule Whois.Record do
               "name server" ->
                 %{record | nameservers: record.nameservers ++ [value]}
 
-              "registrar" ->
+              "dnssec" ->
+                %{record | dnssec: parse_dnssec(record.dnssec, value)}
+
+                "registrar" ->
                 %{record | registrar: value}
 
               "sponsoring registrar" ->
@@ -109,6 +114,17 @@ defmodule Whois.Record do
     case NaiveDateTime.from_iso8601(string) do
       {:ok, datetime} -> datetime
       {:error, _} -> nil
+    end
+  end
+
+  @doc """
+  Parses the DNSSEC value, which may not always be in sync across servers.
+  """
+  defp parse_dnssec(_dnssec, "signedDelegation"), do: "signedDelegation"
+  defp parse_dnssec(dnssec, "unsigned") do
+    case dnssec do
+      "signedDelegation" -> "signedDelegation"
+      _ -> "unsigned"
     end
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,4 @@
-%{"earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"}}
+%{
+  "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], [], "hexpm", "3b1dcad3067985dd8618c38399a8ee9c4e652d52a17a4aae7a6d6fc4fcc24856"},
+  "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm", "f050061c87ad39478c942995b5a20c40f2c0bc06525404613b8b0474cb8bd796"},
+}


### PR DESCRIPTION
as an example that returns both unsigned and signedDelegation results